### PR TITLE
remove gesturehandler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "expo-status-bar": "~1.12.1",
         "react": "18.2.0",
         "react-native": "0.74.5",
-        "react-native-gesture-handler": "^2.20.0",
         "react-native-paper": "^5.12.5",
         "react-native-safe-area-context": "4.10.5",
         "react-native-screens": "3.31.1",
@@ -2117,17 +2116,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@egjs/hammerjs": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
-      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
-      "dependencies": {
-        "@types/hammerjs": "^2.0.36"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -6316,11 +6304,6 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
-    },
-    "node_modules/@types/hammerjs": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
-      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -14068,21 +14051,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-native-gesture-handler": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.20.0.tgz",
-      "integrity": "sha512-rFKqgHRfxQ7uSAivk8vxCiW4SB3G0U7jnv7kZD4Y90K5kp6YrU8Q3tWhxe3Rx55BIvSd3mBe9ZWbWVJ0FsSHPA==",
-      "dependencies": {
-        "@egjs/hammerjs": "^2.0.17",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/react-native-pager-view": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "expo-status-bar": "~1.12.1",
     "react": "18.2.0",
     "react-native": "0.74.5",
-    "react-native-gesture-handler": "^2.20.0",
     "react-native-paper": "^5.12.5",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",

--- a/screens/HouseholdScreen.tsx
+++ b/screens/HouseholdScreen.tsx
@@ -1,26 +1,14 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { StyleSheet, Text, View } from 'react-native';
 import { RootStackParamList } from '../navigators/RootStackNavigator';
-import {
-  PanGestureHandler,
-  GestureHandlerRootView,
-} from 'react-native-gesture-handler';
 
 type HouseholdProps = NativeStackScreenProps<RootStackParamList>;
 
 export default function HouseholdScreen({ navigation }: HouseholdProps) {
-  const goToHome = () => {
-    navigation.navigate('Home');
-  };
-
   return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
-      <PanGestureHandler onGestureEvent={goToHome}>
-        <View style={styles.container}>
-          <Text style={styles.statisticsText}>Hushållssida</Text>
-        </View>
-      </PanGestureHandler>
-    </GestureHandlerRootView>
+    <View style={styles.container}>
+      <Text style={styles.statisticsText}>Hushållssida</Text>
+    </View>
   );
 }
 


### PR DESCRIPTION
Tagit bort gesture-paketet + funktionalitet för att swipa ut ur toptabnavigaton. Det orskade ett error 500 (se nedan)Victor okejat. Vi lägger ev in det i efterhand, för att undvika tidspill under utveckling.

ERROR  Error: GestureDetector must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized.