### PR TITLE
66 gr layout fr homescreen

### DIFF
--- a/navigators/RootStackNavigator.tsx
+++ b/navigators/RootStackNavigator.tsx
@@ -1,7 +1,7 @@
 import { NavigatorScreenParams } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import HomeScreen from '../screens/HomeScreen';
 import ChoreDetailsScreen from '../screens/ChoreDetailsScreen';
+import HomeScreen from '../screens/HomeScreen';
 import TopTabNavigator, { TopTabParamList } from './TopTabNavigator';
 
 export type RootStackParamList = {
@@ -16,7 +16,14 @@ const RootStack = createNativeStackNavigator<RootStackParamList>();
 export default function RootStackNavigator() {
   return (
     <RootStack.Navigator initialRouteName="Home">
-      <RootStack.Screen name="Home" component={HomeScreen} />
+      <RootStack.Screen
+        name="Home"
+        component={HomeScreen}
+        options={{
+          title: 'Startskärm',
+          headerTitleAlign: 'center', // Centrerar titeln.
+        }}
+      />
       <RootStack.Screen
         name="TopTabNavigator"
         component={TopTabNavigator}

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,6 +1,7 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { Button, Card, Text } from 'react-native-paper';
+import { mockedHouseholds } from '../data/data';
 import { RootStackParamList } from '../navigators/RootStackNavigator';
 
 type HomeProps = NativeStackScreenProps<RootStackParamList, 'Home'>;
@@ -9,6 +10,30 @@ export default function HomeScreen({ navigation }: HomeProps) {
   return (
     <View style={styles.root}>
       <View style={styles.householdContainer}>
+        {mockedHouseholds.map((household) => (
+          <Pressable
+            key={household.id}
+            onPress={() =>
+              navigation.navigate('TopTabNavigator', { screen: 'Household' })
+            }
+          >
+            <Card style={styles.card}>
+              <Card.Content style={styles.content}>
+                <Text style={styles.text}>{household.name}</Text>
+                <View style={styles.avatar}>
+                  <Text>🐻</Text>
+                  <Text>🐻</Text>
+                  <Text>🐻</Text>
+                  <Text>🐻</Text>
+                  <Text>🐻</Text>
+                  <Text>🐻</Text>
+                  <Text>🐻</Text>
+                  <Text>🐻</Text>
+                </View>
+              </Card.Content>
+            </Card>
+          </Pressable>
+        ))}
         <Pressable
           onPress={() =>
             navigation.navigate('TopTabNavigator', { screen: 'Household' })
@@ -93,6 +118,7 @@ const styles = StyleSheet.create({
   content: {
     flexDirection: 'row',
     alignItems: 'center',
+    gap: 10,
   },
   text: {
     fontSize: 32,
@@ -103,6 +129,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: 10,
+    maxWidth: '30%',
   },
   buttonContainer: {
     flexDirection: 'row',

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,12 +1,14 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { Button, Card, Text } from 'react-native-paper';
-import { mockedHouseholds } from '../data/data';
 import { RootStackParamList } from '../navigators/RootStackNavigator';
+import { useAppSelector } from '../store/store';
 
 type HomeProps = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
 export default function HomeScreen({ navigation }: HomeProps) {
+  const mockedHouseholds = useAppSelector((state) => state.household);
+
   return (
     <View style={styles.root}>
       <View style={styles.householdContainer}>
@@ -34,44 +36,6 @@ export default function HomeScreen({ navigation }: HomeProps) {
             </Card>
           </Pressable>
         ))}
-        <Pressable
-          onPress={() =>
-            navigation.navigate('TopTabNavigator', { screen: 'Household' })
-          }
-        >
-          <Card style={styles.card}>
-            <Card.Content style={styles.content}>
-              <Text style={styles.text}>HouseHold</Text>
-              <View style={styles.avatar}>
-                <Text>🐻</Text>
-                <Text>🐻</Text>
-                <Text>🐻</Text>
-                <Text>🐻</Text>
-                <Text>🐻</Text>
-                <Text>🐻</Text>
-              </View>
-            </Card.Content>
-          </Card>
-        </Pressable>
-        <Pressable
-          onPress={() =>
-            navigation.navigate('TopTabNavigator', { screen: 'Household' })
-          }
-        >
-          <Card style={styles.card}>
-            <Card.Content style={styles.content}>
-              <Text style={styles.text}>HouseHold</Text>
-              <View style={styles.avatar}>
-                <Text>🐻</Text>
-                <Text>🐻</Text>
-                <Text>🐻</Text>
-                <Text>🐻</Text>
-                <Text>🐻</Text>
-                <Text>🐻</Text>
-              </View>
-            </Card.Content>
-          </Card>
-        </Pressable>
       </View>
       <View style={styles.buttonContainer}>
         <Button

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,31 +1,119 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { Button, StyleSheet, View } from 'react-native';
-import { useAuth } from '../hooks/useAuth';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { Button, Card, Text } from 'react-native-paper';
 import { RootStackParamList } from '../navigators/RootStackNavigator';
 
 type HomeProps = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
 export default function HomeScreen({ navigation }: HomeProps) {
-  const { setAuthState } = useAuth();
-
   return (
-    <View style={styles.container}>
-      <Button
-        title="Go to Household"
-        onPress={() =>
-          navigation.navigate('TopTabNavigator', { screen: 'Household' })
-        }
-      />
-      <Button title="Logga ut" onPress={() => setAuthState(false)} />
+    <View style={styles.root}>
+      <View style={styles.householdContainer}>
+        <Pressable
+          onPress={() =>
+            navigation.navigate('TopTabNavigator', { screen: 'Household' })
+          }
+        >
+          <Card style={styles.card}>
+            <Card.Content style={styles.content}>
+              <Text style={styles.text}>HouseHold</Text>
+              <View style={styles.avatar}>
+                <Text>🐻</Text>
+                <Text>🐻</Text>
+                <Text>🐻</Text>
+                <Text>🐻</Text>
+                <Text>🐻</Text>
+                <Text>🐻</Text>
+              </View>
+            </Card.Content>
+          </Card>
+        </Pressable>
+        <Pressable
+          onPress={() =>
+            navigation.navigate('TopTabNavigator', { screen: 'Household' })
+          }
+        >
+          <Card style={styles.card}>
+            <Card.Content style={styles.content}>
+              <Text style={styles.text}>HouseHold</Text>
+              <View style={styles.avatar}>
+                <Text>🐻</Text>
+                <Text>🐻</Text>
+                <Text>🐻</Text>
+                <Text>🐻</Text>
+                <Text>🐻</Text>
+                <Text>🐻</Text>
+              </View>
+            </Card.Content>
+          </Card>
+        </Pressable>
+      </View>
+      <View style={styles.buttonContainer}>
+        <Button
+          mode="elevated"
+          icon="plus-circle-outline"
+          textColor="black"
+          buttonColor="#fff"
+          labelStyle={styles.buttonText}
+          onPress={() => console.log('Tryckt på Lägg till')}
+        >
+          Lägg till
+        </Button>
+        <Button
+          mode="elevated"
+          icon="arrow-right"
+          textColor="black"
+          buttonColor="#fff"
+          labelStyle={styles.buttonText}
+          contentStyle={{ flexDirection: 'row-reverse' }}
+          onPress={() => console.log('Tryckt på gå med')}
+        >
+          Gå med
+        </Button>
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  root: {
     flex: 1,
+    backgroundColor: '#EAEAEA',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingBottom: 80,
+    paddingTop: 40,
+  },
+  householdContainer: {
+    gap: 20,
+  },
+  card: {
     backgroundColor: '#fff',
+  },
+  content: {
+    flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-around',
+  },
+  text: {
+    fontSize: 32,
+    flex: 1,
+    fontWeight: 700,
+  },
+  avatar: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  buttonText: {
+    fontSize: 20,
+    padding: 2,
   },
 });
+
+// import { useAuth } from '../hooks/useAuth';
+// const { setAuthState } = useAuth();
+// {/* <Button title="Logga ut" onPress={() => setAuthState(false)} /> */}


### PR DESCRIPTION
Layout för startsidan. Finns ingen logik. Hämtar alla hushåll som är mockade från redux. Inte baserat på vem som är inloggad.
Knapparna "lägg till" och "gå med"  har bara console.logs.

Ett hushåll är en knapp och finns ingen logik som som säger att man klickat på något specifikt hushåll - man dirigeras till hushållssidan bara.

Björnarna är hårdkodade för att stylingens proportioners skull - om vi hinner lägga till avatarer där sedan så hamnar de snyggt grupperat. 