### PR TITLE
101 hämta rätt chore på updatechorescreen

### DIFF
--- a/navigators/RootStackNavigator.tsx
+++ b/navigators/RootStackNavigator.tsx
@@ -13,7 +13,7 @@ export type RootStackParamList = {
   TopTabNavigator: NavigatorScreenParams<TopTabParamList>;
   ChoreDetails: { id: string };
   AddChore: undefined;
-  UpdateChore: { id: string };
+  UpdateChore: { choreId: string };
   ChooseChore: undefined;
 };
 

--- a/screens/ChooseChoreScreen.tsx
+++ b/screens/ChooseChoreScreen.tsx
@@ -25,7 +25,7 @@ export default function ChooseChoresScreen({ navigation }: ChooseChoreProps) {
               <Card
                 style={styles.choreCard}
                 onPress={() =>
-                  navigation.navigate('UpdateChore', { id: chore.id })
+                  navigation.navigate('UpdateChore', { choreId: chore.id })
                 }
               >
                 <View style={styles.choreContainer}>

--- a/screens/UpdateChoreScreen.tsx
+++ b/screens/UpdateChoreScreen.tsx
@@ -13,27 +13,26 @@ import {
 import { Button, Card, Text } from 'react-native-paper';
 import { RootStackParamList } from '../navigators/RootStackNavigator';
 import { TopTabParamList } from '../navigators/TopTabNavigator';
-import { updateChore } from '../store/chore/choresSlice';
-import { selectChoresByCurrentHousehold } from '../store/household/householdSelectors';
+import { selectChoreById, updateChore } from '../store/chore/choresSlice';
 import { useAppDispatch, useAppSelector } from '../store/store';
 
 type UpdateChoreProps = CompositeScreenProps<
   NativeStackScreenProps<RootStackParamList, 'UpdateChore'>,
   MaterialTopTabScreenProps<TopTabParamList>
 >;
-export default function UpdateChoreScreen({ navigation }: UpdateChoreProps) {
-  //Hämtar alla chores för ett visst hushåll
-  const chores = useAppSelector(selectChoresByCurrentHousehold);
-  //Hårdkodat vilken syssla som visas.
-  const chore = chores[0];
+export default function UpdateChoreScreen({
+  navigation,
+  route,
+}: UpdateChoreProps) {
+  const chore = useAppSelector(selectChoreById(route.params.id));
 
-  const [newChoreTitle, setNewChoreTitle] = useState(chore.title);
+  const [newChoreTitle, setNewChoreTitle] = useState(chore!.title);
   const [newChoreDescription, setNewChoreDescription] = useState(
-    chore.description,
+    chore!.description,
   );
-  const [newChoreInterval, setNewChoreInterval] = useState(chore.interval);
+  const [newChoreInterval, setNewChoreInterval] = useState(chore!.interval);
   const [newChoreEnergyWeight, setNewChoreEnergyWeight] = useState(
-    chore.energyWeight,
+    chore!.energyWeight,
   );
   const [showIntervalPicker, setShowIntervalPicker] = useState(false);
   const [showEnergyWeightPicker, setShowEnergyWeightPicker] = useState(false);
@@ -42,12 +41,12 @@ export default function UpdateChoreScreen({ navigation }: UpdateChoreProps) {
   const handleUpdateChore = () => {
     dispatch(
       updateChore({
-        id: chore.id,
+        id: chore!.id,
         title: newChoreTitle,
         description: newChoreDescription,
         interval: newChoreInterval,
         energyWeight: newChoreEnergyWeight,
-        householdId: chore.householdId,
+        householdId: chore!.householdId,
       }),
     );
     navigation.navigate('Chores');

--- a/screens/UpdateChoreScreen.tsx
+++ b/screens/UpdateChoreScreen.tsx
@@ -24,7 +24,7 @@ export default function UpdateChoreScreen({
   navigation,
   route,
 }: UpdateChoreProps) {
-  const chore = useAppSelector(selectChoreById(route.params.id));
+  const chore = useAppSelector(selectChoreById(route.params.choreId));
 
   const [newChoreTitle, setNewChoreTitle] = useState(chore!.title);
   const [newChoreDescription, setNewChoreDescription] = useState(

--- a/store/chore/choresSlice.ts
+++ b/store/chore/choresSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { mockedChores } from '../../data/data';
 import { Chore } from '../../data/types';
+import { RootState } from '../store';
 
 const choreSlice = createSlice({
   name: 'chore',
@@ -24,3 +25,8 @@ const choreSlice = createSlice({
 export const choreReducer = choreSlice.reducer;
 export const { addChore, updateChore } = choreSlice.actions;
 // export const { addChore, deleteChore, updateChore } = choreSlice.actions;
+
+// SELECTORS
+
+export const selectChoreById = (ChoreId: string) => (state: RootState) =>
+  state.chore.find((chore) => chore.id === ChoreId);


### PR DESCRIPTION
Skapat en selector som plockar ut chore utefter dess id. Selectorn ligger i slicen under rubriken "Selectors".
Tagit bort den hårdkodad chore på updatechorescreen och använt selectorn istället. 
Ändrat param namn från id till choreId för UpdateChore för att göra koden mer lättläst.