### PR TITLE
6 en ägare ska kunna göra andra till ägare

### DIFF
--- a/screens/HouseholdScreen.tsx
+++ b/screens/HouseholdScreen.tsx
@@ -134,11 +134,11 @@ export default function HouseholdScreen({ route }: HouseholdProps) {
         return;
       }
       const updateMember = {
-        id: member.id.toString(),
-        userId: member.userId.toString(),
-        householdId: member.householdId.toString(),
-        avatar: member.avatar.toString(),
-        name: member.name.toString(),
+        id: member.id,
+        userId: member.userId,
+        householdId: member.householdId,
+        avatar: member.avatar,
+        name: member.name,
         owner: true,
         isActive: member.isActive,
         isRequest: member.isRequest,

--- a/screens/HouseholdScreen.tsx
+++ b/screens/HouseholdScreen.tsx
@@ -129,8 +129,10 @@ export default function HouseholdScreen({ route }: HouseholdProps) {
   );
   const AllHouseholdMembers = () => {
     const handleMakeOwner = (member: HouseholdMember) => {
-      if (!member) return;
-
+      if (!member) {
+        console.error('No member to update!');
+        return;
+      }
       const updateMember = {
         id: member.id.toString(),
         userId: member.userId.toString(),
@@ -156,7 +158,7 @@ export default function HouseholdScreen({ route }: HouseholdProps) {
                   style={styles.avatar}
                 />
                 {isOwner && (
-                  <View>
+                  <View style={{ paddingRight: 3 }}>
                     <Pressable onPress={() => handleMakeOwner(member)}>
                       <MaterialIcons
                         name="face"
@@ -166,7 +168,6 @@ export default function HouseholdScreen({ route }: HouseholdProps) {
                     </Pressable>
                   </View>
                 )}
-
                 <Text style={styles.memberName}>
                   {member.name || 'Medlemsnamn'}
                 </Text>
@@ -177,49 +178,6 @@ export default function HouseholdScreen({ route }: HouseholdProps) {
       </Card>
     );
   };
-  // const AllHouseholdMembers = ({ membersInCurrentHousehold, isOwner }) => {
-  //   const [members, setMembers] = useState(membersInCurrentHousehold);
-
-  //   const handlePress = (memberId) => {
-  //     setMembers((prevMembers) =>
-  //       prevMembers.map((member) =>
-  //         member.id === memberId ? { ...member, isOwner: true } : member,
-  //       ),
-  //     );
-  //   };
-  //   return (
-  //     <Card style={styles.card}>
-  //       <Card.Content>
-  //         <Text variant="titleLarge">Hushållsmedlemmar</Text>
-  //         <View style={styles.membersContainer}>
-  //           {members.map((member) => (
-  //             <View key={member.id} style={styles.memberItem}>
-  //               <Avatar.Image
-  //                 size={30}
-  //                 source={avatarsMap[member.avatar].icon}
-  //                 style={styles.avatar}
-  //               />
-  //               {isOwner && (
-  //                 <View>
-  //                   <Pressable onPress={() => handlePress(member.id)}>
-  //                     <MaterialIcons
-  //                       name="face"
-  //                       size={20}
-  //                       color={member.isOwner ? 'green' : '#777'}
-  //                     />
-  //                   </Pressable>
-  //                 </View>
-  //               )}
-  //               <Text style={styles.memberName}>
-  //                 {member.name || 'Medlemsnamn'}
-  //               </Text>
-  //             </View>
-  //           ))}
-  //         </View>
-  //       </Card.Content>
-  //     </Card>
-  //   );
-  // };
 
   const RemoveHousehold = () => (
     <View style={styles.binIcon}>
@@ -321,7 +279,10 @@ const styles = StyleSheet.create({
     marginTop: 10,
   },
   memberName: {
+    maxWidth: 100,
+    padding: 2,
     fontSize: 16,
+    flexWrap: 'wrap',
   },
   errorText: {
     fontSize: 18,

--- a/screens/HouseholdScreen.tsx
+++ b/screens/HouseholdScreen.tsx
@@ -1,19 +1,24 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Pressable, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Avatar, Card, Text, TextInput } from 'react-native-paper';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import { avatarsMap } from '../data/data';
+import { HouseholdMember } from '../data/types';
 import { TopTabParamList } from '../navigators/TopTabNavigator';
 import { setHouseholdName } from '../store/household/householdSlice';
-import { setCurrentHouseholdMember } from '../store/householdmember/householdmemberSlice';
 import { selectMembersInCurrentHousehold } from '../store/householdmember/householdmemberSelectors';
-import { selectHouseholdMembersList } from '../store/sharedSelectors';
-import { useAppDispatch, useAppSelector } from '../store/store';
+import {
+  setCurrentHouseholdMember,
+  updateHouseholdMember,
+} from '../store/householdmember/householdmemberSlice';
 import {
   selectCurrentHousehold,
+  selectCurrentHouseholdMember,
   selectCurrentUser,
+  selectHouseholdMembersList,
 } from '../store/sharedSelectors';
+import { useAppDispatch, useAppSelector } from '../store/store';
 
 type HouseholdProps = NativeStackScreenProps<TopTabParamList, 'Household'>;
 
@@ -25,6 +30,9 @@ export default function HouseholdScreen({ route }: HouseholdProps) {
   const membersInCurrentHousehold = useAppSelector(
     selectMembersInCurrentHousehold,
   );
+  const currentHouseholdMember = useAppSelector(selectCurrentHouseholdMember);
+
+  const isOwner = currentHouseholdMember?.owner ?? false;
 
   useEffect(() => {
     if (currentUser?.uid) {
@@ -119,27 +127,99 @@ export default function HouseholdScreen({ route }: HouseholdProps) {
       </View>
     </View>
   );
-  const AllHouseholdMembers = () => (
-    <Card style={styles.card}>
-      <Card.Content>
-        <Text variant="titleLarge">Hushållsmedlemmar</Text>
-        <View style={styles.membersContainer}>
-          {membersInCurrentHousehold.map((member) => (
-            <View key={member.id} style={styles.memberItem}>
-              <Avatar.Image
-                size={30}
-                source={avatarsMap[member.avatar].icon}
-                style={styles.avatar}
-              />
-              <Text style={styles.memberName}>
-                {member.name || 'Medlemsnamn'}
-              </Text>
-            </View>
-          ))}
-        </View>
-      </Card.Content>
-    </Card>
-  );
+  const AllHouseholdMembers = () => {
+    const handleMakeOwner = (member: HouseholdMember) => {
+      if (!member) return;
+
+      const updateMember = {
+        id: member.id.toString(),
+        userId: member.userId.toString(),
+        householdId: member.householdId.toString(),
+        avatar: member.avatar.toString(),
+        name: member.name.toString(),
+        owner: true,
+        isActive: member.isActive,
+        isRequest: member.isRequest,
+      };
+      dispatch(updateHouseholdMember(updateMember));
+    };
+    return (
+      <Card style={styles.card}>
+        <Card.Content>
+          <Text variant="titleLarge">Hushållsmedlemmar</Text>
+          <View style={styles.membersContainer}>
+            {membersInCurrentHousehold.map((member) => (
+              <View key={member.id} style={styles.memberItem}>
+                <Avatar.Image
+                  size={30}
+                  source={avatarsMap[member.avatar].icon}
+                  style={styles.avatar}
+                />
+                {isOwner && (
+                  <View>
+                    <Pressable onPress={() => handleMakeOwner(member)}>
+                      <MaterialIcons
+                        name="face"
+                        size={20}
+                        color={member.owner ? 'green' : '#777'}
+                      />
+                    </Pressable>
+                  </View>
+                )}
+
+                <Text style={styles.memberName}>
+                  {member.name || 'Medlemsnamn'}
+                </Text>
+              </View>
+            ))}
+          </View>
+        </Card.Content>
+      </Card>
+    );
+  };
+  // const AllHouseholdMembers = ({ membersInCurrentHousehold, isOwner }) => {
+  //   const [members, setMembers] = useState(membersInCurrentHousehold);
+
+  //   const handlePress = (memberId) => {
+  //     setMembers((prevMembers) =>
+  //       prevMembers.map((member) =>
+  //         member.id === memberId ? { ...member, isOwner: true } : member,
+  //       ),
+  //     );
+  //   };
+  //   return (
+  //     <Card style={styles.card}>
+  //       <Card.Content>
+  //         <Text variant="titleLarge">Hushållsmedlemmar</Text>
+  //         <View style={styles.membersContainer}>
+  //           {members.map((member) => (
+  //             <View key={member.id} style={styles.memberItem}>
+  //               <Avatar.Image
+  //                 size={30}
+  //                 source={avatarsMap[member.avatar].icon}
+  //                 style={styles.avatar}
+  //               />
+  //               {isOwner && (
+  //                 <View>
+  //                   <Pressable onPress={() => handlePress(member.id)}>
+  //                     <MaterialIcons
+  //                       name="face"
+  //                       size={20}
+  //                       color={member.isOwner ? 'green' : '#777'}
+  //                     />
+  //                   </Pressable>
+  //                 </View>
+  //               )}
+  //               <Text style={styles.memberName}>
+  //                 {member.name || 'Medlemsnamn'}
+  //               </Text>
+  //             </View>
+  //           ))}
+  //         </View>
+  //       </Card.Content>
+  //     </Card>
+  //   );
+  // };
 
   const RemoveHousehold = () => (
     <View style={styles.binIcon}>


### PR DESCRIPTION
Är man ägare kan man nu trycka på en liten icon på hushållssidan för att göra andra till ägare. Är bilden grön så är man ägare. 
Kopplat till Redux.
Det stod ingenting om att man skulle kunna göra någon till INTE ägare så jag struntade i det. Det går bara åt ett håll alltså då det var kravet.

![Skärmavbild 2024-10-29 kl  23 33 32](https://github.com/user-attachments/assets/de3d99a9-fc77-4e5b-b83a-d75934b46252)
